### PR TITLE
Use application context for background operations

### DIFF
--- a/android/src/main/kotlin/com/cavadalab/dchs_flutter_beacon/FlutterBeaconBroadcast.kt
+++ b/android/src/main/kotlin/com/cavadalab/dchs_flutter_beacon/FlutterBeaconBroadcast.kt
@@ -4,6 +4,7 @@ import android.Manifest
 import android.app.Activity
 import android.bluetooth.le.AdvertiseCallback
 import android.bluetooth.le.AdvertiseSettings
+import android.content.Context
 import android.content.pm.PackageManager
 import android.os.Build
 import android.util.Log
@@ -14,13 +15,13 @@ import org.altbeacon.beacon.BeaconParser
 import org.altbeacon.beacon.BeaconTransmitter
 import io.flutter.plugin.common.MethodChannel
 
-class FlutterBeaconBroadcast(private val activity: Activity, iBeaconLayout: BeaconParser) {
+class FlutterBeaconBroadcast(private val context: Context, iBeaconLayout: BeaconParser) {
     companion object {
         private val TAG = FlutterBeaconBroadcast::class.java.simpleName
         const val REQUEST_CODE_BLUETOOTH_ADVERTISE = 1236
     }
 
-    private val beaconTransmitter: BeaconTransmitter = BeaconTransmitter(activity.applicationContext, iBeaconLayout)
+    private val beaconTransmitter: BeaconTransmitter = BeaconTransmitter(context.applicationContext, iBeaconLayout)
     private var pendingResult: MethodChannel.Result? = null
     private var beacon: Beacon? = null
     private var beaconMap: Map<String, Any?>? = null
@@ -62,15 +63,17 @@ class FlutterBeaconBroadcast(private val activity: Activity, iBeaconLayout: Beac
     }
 
     private fun hasBluetoothAdvertisePermission(): Boolean {
-        return ContextCompat.checkSelfPermission(activity, Manifest.permission.BLUETOOTH_ADVERTISE) == PackageManager.PERMISSION_GRANTED
+        return ContextCompat.checkSelfPermission(context, Manifest.permission.BLUETOOTH_ADVERTISE) == PackageManager.PERMISSION_GRANTED
     }
 
     private fun requestBluetoothAdvertisePermission() {
-        ActivityCompat.requestPermissions(
-            activity,
-            arrayOf(Manifest.permission.BLUETOOTH_ADVERTISE),
-            REQUEST_CODE_BLUETOOTH_ADVERTISE
-        )
+        if (context is Activity) {
+            ActivityCompat.requestPermissions(
+                context,
+                arrayOf(Manifest.permission.BLUETOOTH_ADVERTISE),
+                REQUEST_CODE_BLUETOOTH_ADVERTISE
+            )
+        }
     }
 
     private fun startAdvertising(beacon: Beacon?, map: Map<String, Any?>?) {

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -55,7 +55,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.6.5"
+    version: "0.6.6"
   fake_async:
     dependency: transitive
     description:


### PR DESCRIPTION
This pull request solves the issue #6.
It refactors the Android plugin codebase to consistently use `Context` instead of `Activity` where possible, improving lifecycle handling and background operation support. The changes ensure that all beacon-related classes and methods can operate with either an `Activity` or a general `Context`, allowing for safer and more flexible usage, particularly when the app is running in the background.