### PR TITLE
Support Android beacon scanning from headless engines

### DIFF
--- a/android/src/main/kotlin/com/cavadalab/dchs_flutter_beacon/DchsFlutterBeaconPlugin.kt
+++ b/android/src/main/kotlin/com/cavadalab/dchs_flutter_beacon/DchsFlutterBeaconPlugin.kt
@@ -4,6 +4,7 @@ import android.os.Build
 import android.util.Log
 
 import android.app.Activity
+import android.content.Context
 import android.Manifest
 import android.content.Intent
 import android.content.pm.PackageManager
@@ -45,9 +46,13 @@ class DchsFlutterBeaconPlugin : FlutterPlugin, ActivityAware, MethodChannel.Meth
 
     override fun onAttachedToEngine(@NonNull binding: FlutterPlugin.FlutterPluginBinding) {
         this.flutterPluginBinding = binding
+        setupChannels(binding.binaryMessenger, binding.applicationContext)
     }
 
     override fun onDetachedFromEngine(@NonNull binding: FlutterPlugin.FlutterPluginBinding) {
+        stopBeaconSession()
+        teardownChannels()
+        clearActivityScopedReferences()
         this.flutterPluginBinding = null
     }
 
@@ -55,8 +60,12 @@ class DchsFlutterBeaconPlugin : FlutterPlugin, ActivityAware, MethodChannel.Meth
     override fun onAttachedToActivity(binding: ActivityPluginBinding) {
         this.activityPluginBinding = binding
         this.activity = binding.activity
+        activityPluginBinding?.addActivityResultListener(this)
+        activityPluginBinding?.addRequestPermissionsResultListener(this)
+        platform?.setActivity(binding.activity)
 
-        setupChannels(flutterPluginBinding!!.binaryMessenger, activity!!)
+        val iBeaconLayout = BeaconParser().setBeaconLayout("m:2-3=0215,i:4-19,i:20-21,i:22-23,p:24-24")
+        beaconBroadcast = FlutterBeaconBroadcast(binding.activity, iBeaconLayout)
     }
 
     override fun onDetachedFromActivityForConfigChanges() {
@@ -68,17 +77,18 @@ class DchsFlutterBeaconPlugin : FlutterPlugin, ActivityAware, MethodChannel.Meth
     }
 
     override fun onDetachedFromActivity() {
-        stopBeaconSession()
-        teardownChannels()
-        clearActivityScopedReferences()
+        activityPluginBinding?.removeActivityResultListener(this)
+        activityPluginBinding?.removeRequestPermissionsResultListener(this)
+        activityPluginBinding = null
+        platform?.setActivity(null)
+        beaconBroadcast = null
+        flutterResultBluetooth = null
         this.activity = null
     }
 
-    private fun setupChannels(messenger: BinaryMessenger, activity: Activity) {
-        activityPluginBinding?.addActivityResultListener(this)
-        activityPluginBinding?.addRequestPermissionsResultListener(this)
-
-        beaconManager = BeaconManager.getInstanceForApplication(activity.applicationContext)
+    private fun setupChannels(messenger: BinaryMessenger, context: Context) {
+        val appContext = context.applicationContext
+        beaconManager = BeaconManager.getInstanceForApplication(appContext)
 
         val iBeaconLayout = BeaconParser().setBeaconLayout("m:2-3=0215,i:4-19,i:20-21,i:22-23,p:24-24")
 
@@ -87,10 +97,8 @@ class DchsFlutterBeaconPlugin : FlutterPlugin, ActivityAware, MethodChannel.Meth
             beaconManager!!.beaconParsers.add(iBeaconLayout)
         }
 
-        platform = FlutterPlatform(activity)
-        beaconScanner = FlutterBeaconScanner(this, activity)
-        beaconBroadcast = FlutterBeaconBroadcast(activity, iBeaconLayout)
-
+        platform = FlutterPlatform(appContext, activity)
+        beaconScanner = FlutterBeaconScanner(this, appContext)
         channel = MethodChannel(messenger, "flutter_beacon")
         channel.setMethodCallHandler(this)
 
@@ -101,7 +109,7 @@ class DchsFlutterBeaconPlugin : FlutterPlugin, ActivityAware, MethodChannel.Meth
         eventChannelMonitoring.setStreamHandler(beaconScanner!!.monitoringStreamHandler)
 
         eventChannelBluetoothState = EventChannel(messenger, "flutter_bluetooth_state_changed")
-        eventChannelBluetoothState.setStreamHandler(FlutterBluetoothStateReceiver(activity))
+        eventChannelBluetoothState.setStreamHandler(FlutterBluetoothStateReceiver(appContext))
 
         eventChannelAuthorizationStatus = EventChannel(messenger, "flutter_authorization_status_changed")
         eventChannelAuthorizationStatus.setStreamHandler(locationAuthorizationStatusStreamHandler)
@@ -125,9 +133,7 @@ class DchsFlutterBeaconPlugin : FlutterPlugin, ActivityAware, MethodChannel.Meth
         val scanner = beaconScanner ?: return
 
         scanner.stopRanging()
-        manager.removeAllRangeNotifiers()
         scanner.stopMonitoring()
-        manager.removeAllMonitorNotifiers()
 
         if (manager.isBound(scanner.beaconConsumer)) {
             manager.unbind(scanner.beaconConsumer)
@@ -244,7 +250,10 @@ class DchsFlutterBeaconPlugin : FlutterPlugin, ActivityAware, MethodChannel.Meth
             "requestAuthorization" -> {
                 if (!platform!!.checkLocationServicesPermission()) {
                     this.flutterResult = result
-                    platform!!.requestAuthorization()
+                    if (!platform!!.requestAuthorization()) {
+                        this.flutterResult = null
+                        result.error("Beacon", "Activity is required to request permissions", null)
+                    }
                     return
                 }
 
@@ -255,7 +264,10 @@ class DchsFlutterBeaconPlugin : FlutterPlugin, ActivityAware, MethodChannel.Meth
             "openBluetoothSettings" -> {
                 if (!platform!!.checkBluetoothIfEnabled()) {
                     this.flutterResultBluetooth = result
-                    platform!!.openBluetoothSettings()
+                    if (!platform!!.openBluetoothSettings()) {
+                        this.flutterResultBluetooth = null
+                        result.error("Beacon", "Activity is required to open Bluetooth settings", null)
+                    }
                     return
                 }
                 result.success(true)
@@ -301,10 +313,16 @@ class DchsFlutterBeaconPlugin : FlutterPlugin, ActivityAware, MethodChannel.Meth
         flutterResult = result
         when {
             !platform!!.checkBluetoothIfEnabled() -> {
-                platform!!.openBluetoothSettings()
+                if (!platform!!.openBluetoothSettings()) {
+                    flutterResult = null
+                    result?.error("Beacon", "Activity is required to open Bluetooth settings", null)
+                }
             }
             !platform!!.checkLocationServicesPermission() -> {
-                platform!!.requestAuthorization()
+                if (!platform!!.requestAuthorization()) {
+                    flutterResult = null
+                    result?.error("Beacon", "Activity is required to request permissions", null)
+                }
             }
             !platform!!.checkLocationServicesIfEnabled() -> {
                 platform!!.openLocationSettings()

--- a/android/src/main/kotlin/com/cavadalab/dchs_flutter_beacon/FlutterBeaconScanner.kt
+++ b/android/src/main/kotlin/com/cavadalab/dchs_flutter_beacon/FlutterBeaconScanner.kt
@@ -1,6 +1,5 @@
 package com.cavadalab.dchs_flutter_beacon
 
-import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.content.ServiceConnection
@@ -11,7 +10,9 @@ import android.util.Log
 import io.flutter.plugin.common.EventChannel
 import org.altbeacon.beacon.*
 
-class FlutterBeaconScanner(private val plugin: DchsFlutterBeaconPlugin,  private val activity: Activity) {
+class FlutterBeaconScanner(private val plugin: DchsFlutterBeaconPlugin, context: Context) {
+
+    private val context = context.applicationContext
 
     companion object {
         private val TAG = FlutterBeaconScanner::class.java.simpleName
@@ -68,7 +69,7 @@ class FlutterBeaconScanner(private val plugin: DchsFlutterBeaconPlugin,  private
         try {
             val beaconManager = plugin.getBeaconManager()
             beaconManager?.apply {
-                removeAllRangeNotifiers()
+                removeRangeNotifier(rangeNotifier)
                 addRangeNotifier(rangeNotifier)
                 regionRanging?.forEach { region ->
                     startRangingBeaconsInRegion(region)
@@ -154,7 +155,7 @@ class FlutterBeaconScanner(private val plugin: DchsFlutterBeaconPlugin,  private
         try {
             val beaconManager = plugin.getBeaconManager()
             beaconManager?.apply {
-                removeAllMonitorNotifiers()
+                removeMonitorNotifier(monitorNotifier)
                 addMonitorNotifier(monitorNotifier)
                 regionMonitoring?.forEach { region ->
                     startMonitoringBeaconsInRegion(region)
@@ -228,15 +229,15 @@ class FlutterBeaconScanner(private val plugin: DchsFlutterBeaconPlugin,  private
         }
 
         override fun getApplicationContext(): Context {
-            return activity.applicationContext!!
+            return context
         }
 
         override fun unbindService(connection: ServiceConnection) {
-            activity.unbindService(connection)
+            context.unbindService(connection)
         }
 
         override fun bindService(intent: Intent, connection: ServiceConnection, mode: Int): Boolean {
-            return activity.bindService(intent, connection, mode)
+            return context.bindService(intent, connection, mode)
         }
     }
 }

--- a/android/src/main/kotlin/com/cavadalab/dchs_flutter_beacon/FlutterPlatform.kt
+++ b/android/src/main/kotlin/com/cavadalab/dchs_flutter_beacon/FlutterPlatform.kt
@@ -16,21 +16,28 @@ import androidx.core.content.ContextCompat
 import org.altbeacon.beacon.BeaconTransmitter
 import java.lang.ref.WeakReference
 
-class FlutterPlatform(activity: Activity) {
-    private val activityWeakReference = WeakReference(activity)
+class FlutterPlatform(context: Context, activity: Activity?) {
+    private val context = context.applicationContext
+    private var activityWeakReference = WeakReference(activity)
 
     private val activity: Activity?
         get() = activityWeakReference.get()
 
+    fun setActivity(activity: Activity?) {
+        activityWeakReference = WeakReference(activity)
+    }
+
     fun openLocationSettings() {
         val intent = Intent(Settings.ACTION_LOCATION_SOURCE_SETTINGS)
         intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
-        activity?.startActivity(intent)
+        context.startActivity(intent)
     }
 
-    fun openBluetoothSettings() {
+    fun openBluetoothSettings(): Boolean {
+        val act = activity ?: return false
         val intent = Intent(BluetoothAdapter.ACTION_REQUEST_ENABLE)
-        activity?.startActivityForResult(intent, DchsFlutterBeaconPlugin.REQUEST_CODE_BLUETOOTH)
+        act.startActivityForResult(intent, DchsFlutterBeaconPlugin.REQUEST_CODE_BLUETOOTH)
+        return true
     }
 
     fun requiredAuthorizationPermissions(): Array<String> {
@@ -46,40 +53,39 @@ class FlutterPlatform(activity: Activity) {
         }
     }
 
-    fun requestAuthorization() {
+    fun requestAuthorization(): Boolean {
         val permissions = requiredAuthorizationPermissions()
         if (permissions.isEmpty()) {
-            return
+            return true
         }
 
-        activity?.let {
-            ActivityCompat.requestPermissions(
-                it,
-                permissions,
-                DchsFlutterBeaconPlugin.REQUEST_CODE_LOCATION
-            )
-        }
+        val act = activity ?: return false
+        ActivityCompat.requestPermissions(
+            act,
+            permissions,
+            DchsFlutterBeaconPlugin.REQUEST_CODE_LOCATION
+        )
+        return true
     }
 
     fun checkLocationServicesPermission(): Boolean {
-        val act = activity ?: return false
         return when {
             Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
                 // Android 12+: BLUETOOTH_SCAN is required for BLE scanning;
                 // ACCESS_FINE_LOCATION is also needed unless neverForLocation is set.
                 ContextCompat.checkSelfPermission(
-                    act,
+                    context,
                     Manifest.permission.ACCESS_FINE_LOCATION
                 ) == PackageManager.PERMISSION_GRANTED &&
                 ContextCompat.checkSelfPermission(
-                    act,
+                    context,
                     Manifest.permission.BLUETOOTH_SCAN
                 ) == PackageManager.PERMISSION_GRANTED
             }
             Build.VERSION.SDK_INT >= Build.VERSION_CODES.M -> {
                 // Android 6–11: ACCESS_FINE_LOCATION is required for BLE scanning on Android 10+.
                 ContextCompat.checkSelfPermission(
-                    act,
+                    context,
                     Manifest.permission.ACCESS_FINE_LOCATION
                 ) == PackageManager.PERMISSION_GRANTED
             }
@@ -88,15 +94,14 @@ class FlutterPlatform(activity: Activity) {
     }
 
     fun checkLocationServicesIfEnabled(): Boolean {
-        val act = activity ?: return false
         return when {
             Build.VERSION.SDK_INT >= Build.VERSION_CODES.P -> {
-                val locationManager = act.getSystemService(Context.LOCATION_SERVICE) as? LocationManager
+                val locationManager = context.getSystemService(Context.LOCATION_SERVICE) as? LocationManager
                 locationManager?.isLocationEnabled ?: false
             }
             Build.VERSION.SDK_INT >= Build.VERSION_CODES.M -> {
                 val mode = Settings.Secure.getInt(
-                    act.contentResolver,
+                    context.contentResolver,
                     Settings.Secure.LOCATION_MODE,
                     Settings.Secure.LOCATION_MODE_OFF
                 )
@@ -108,16 +113,14 @@ class FlutterPlatform(activity: Activity) {
 
     @SuppressLint("MissingPermission")
     fun checkBluetoothIfEnabled(): Boolean {
-        val act = activity ?: throw RuntimeException("Activity is null")
-        val bluetoothManager = act.getSystemService(Context.BLUETOOTH_SERVICE) as? BluetoothManager
+        val bluetoothManager = context.getSystemService(Context.BLUETOOTH_SERVICE) as? BluetoothManager
             ?: throw RuntimeException("No Bluetooth service")
         val adapter = bluetoothManager.adapter
         return adapter?.isEnabled ?: false
     }
 
     fun isBroadcastSupported(): Boolean {
-        val act = activity ?: return false
-        return BeaconTransmitter.checkTransmissionSupported(act) == BeaconTransmitter.SUPPORTED
+        return BeaconTransmitter.checkTransmissionSupported(context) == BeaconTransmitter.SUPPORTED
     }
 
     fun shouldShowRequestPermissionRationale(permission: String): Boolean {


### PR DESCRIPTION
## Summary

This PR fixes Android plugin registration and scanning lifecycle behavior for Flutter headless engines.

This moves Android method/event channel setup from `onAttachedToActivity` to `onAttachedToEngine`, allowing the plugin to be available in engines that do not have an attached Activity, such as foreground service or background isolates.

Previously, Android channel registration only happened in `onAttachedToActivity`. In a headless foreground-service engine, no Activity is attached, so calls such as `initializeAndCheck` could fail with `MissingPluginException`.

After making the plugin available to headless engines, scanning also needed to avoid process-wide AltBeacon cleanup. `BeaconManager` is shared per application process, so `removeAllRangeNotifiers()` and `removeAllMonitorNotifiers()` could remove callbacks owned by another Flutter engine.


## Changes

- Register Flutter method and event channels during `onAttachedToEngine`
- Use application context for beacon scanning, Bluetooth/location checks, and AltBeacon service binding
- Keep Activity-dependent behavior, such as permission prompts, Bluetooth settings, and beacon broadcasting, scoped to Activity attachment
- Return explicit errors when a headless engine tries to start Activity-only flows
- Avoid removing all AltBeacon range/monitor notifiers, so one Flutter engine does not stop scanning callbacks owned by another engine

## Validation

- Verified in a foreground-service/headless-engine use case that initialization succeeds
- Verified Android beacon scanning receives beacon data
- Verified scanning continues when the main app UI is closed while the foreground service remains running